### PR TITLE
Fixes #3 order by oldest first.

### DIFF
--- a/Heroesprofile.Uploader.Common/Manager.cs
+++ b/Heroesprofile.Uploader.Common/Manager.cs
@@ -181,7 +181,7 @@ namespace Heroesprofile.Uploader.Common
             var lookup = new HashSet<ReplayFile>(replays);
             var comparer = new ReplayFile.ReplayFileComparer();
             replays.AddRange(_monitor.ScanReplays().Select(x => new ReplayFile(x)).Where(x => !lookup.Contains(x, comparer)));
-            return replays.OrderByDescending(x => x.Created).ToList();
+            return replays.OrderBy(x => x.Created).ThenByDescending(x=> x.Created.TimeOfDay).ToList();
         }
 
         /// <summary>


### PR DESCRIPTION
Changed orderByDescending to be order by ascending on the date, then order by descending on the time so that the oldest will be first. Fixes #3 