### PR TITLE
Removes replay deletion and twitch extension from tool

### DIFF
--- a/Heroesprofile.Uploader.Common/Manager.cs
+++ b/Heroesprofile.Uploader.Common/Manager.cs
@@ -206,7 +206,7 @@ namespace Heroesprofile.Uploader.Common
                     }
                     SaveReplayList();
                     if (ShouldDelete(file, replay)) {
-                        DeleteReplay(file);
+                        //DeleteReplay(file);
                     }
                 }
                 catch (Exception ex) {

--- a/Heroesprofile.Uploader.Windows/MainWindow.xaml
+++ b/Heroesprofile.Uploader.Windows/MainWindow.xaml
@@ -63,9 +63,7 @@
                 <CheckBox IsChecked="{Binding App.Settings.MinimizeToTray}" Content="Minimize to tray" Height="23"  />
                 <CheckBox IsChecked="{Binding App.Settings.PreMatchPage}" Content="Prematch Page" Height="23"  Margin="0,0,8,0" IsEnabled="True"  />
                 <CheckBox IsChecked="{Binding App.Settings.PostMatchPage}" Content="Postmatch Page" Height="23"  Margin="0,0,8,0" IsEnabled="True"  />
-                <CheckBox x:Name="Twitch_Extension_Checkbox" IsChecked="{Binding App.Settings.HPTwitchExtension}" Content="Twitch Extension" Height="23"  Margin="0,0,8,0" IsEnabled="{Binding App.Settings.HPTwitchValidated}"/>
                 <Button HorizontalAlignment="Stretch" Content="Show log" Click="ShowLog_Click" Margin="0, 8, 0, 0" />
-                <Button HorizontalAlignment="Stretch" Content="Settings" Click="Settings_Click" Margin="0, 8, 0, 0" />
             </StackPanel>
         </DockPanel>
         <StackPanel Grid.ColumnSpan="2" Grid.Row="2" Margin="0, 12, 0, 0" Visibility="{Binding App.UpdateAvailable, Converter={StaticResource visibilityConverter}}" Orientation="Horizontal">

--- a/Heroesprofile.Uploader.Windows/MainWindow.xaml.cs
+++ b/Heroesprofile.Uploader.Windows/MainWindow.xaml.cs
@@ -18,8 +18,6 @@ namespace Heroesprofile.Uploader.Windows
         {
             InitializeComponent();
 
-            Twitch_Extension_Checkbox.Checked += Twitch_Extension_Checkbox_Checked;
-            Twitch_Extension_Checkbox.Unchecked += Twitch_Extension_Checkbox_Unchecked;
         }
 
         private void Twitch_Extension_Checkbox_Checked(object sender, RoutedEventArgs e)
@@ -64,7 +62,6 @@ namespace Heroesprofile.Uploader.Windows
             var settings = new SettingsWindow() { Owner = this, DataContext = this };
             settings.ShowDialog();
 
-            Twitch_Extension_Checkbox.IsEnabled = Settings.Default.HPTwitchValidated;
         }
 
         private async void Restart_Click(object sender, RoutedEventArgs e)

--- a/Heroesprofile.Uploader.Windows/Properties/AssemblyInfo.cs
+++ b/Heroesprofile.Uploader.Windows/Properties/AssemblyInfo.cs
@@ -52,6 +52,6 @@ using System.Windows;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.0.8")]
-[assembly: AssemblyFileVersion("2.0.8")]
+[assembly: AssemblyVersion("2.0.9")]
+[assembly: AssemblyFileVersion("2.0.9")]
 [assembly: AssemblyInformationalVersion("1.0.0")]

--- a/Heroesprofile.Uploader.Windows/SettingsWindow.xaml
+++ b/Heroesprofile.Uploader.Windows/SettingsWindow.xaml
@@ -18,20 +18,7 @@
             <ColumnDefinition Width="auto" />
             <ColumnDefinition Width="auto" />
         </Grid.ColumnDefinitions>
-        <StackPanel Grid.Column="0" Margin="20" helpers:MarginSetter.Margin="0, 8, 0, 0">
-            <TextBlock Text="Delete replays after upload:" FontWeight="Bold" Margin="0, 0, 1, 0" />
-            <TextBlock HorizontalAlignment="Left" FontSize="10" TextWrapping="Wrap" MaxWidth="150" Margin="0, 0, 1, 0"
-                       Text="Warning! This feature is not yet extensively tested, use at your own risk and make a backup of all important replays" />
-            <CheckBox Content="PTR" IsChecked="{Binding App.Settings.DeleteAfterUpload, Converter={StaticResource flags}, ConverterParameter={x:Static common:DeleteFiles.PTR}, Mode=TwoWay}" />
-            <CheckBox Content="AI" IsChecked="{Binding App.Settings.DeleteAfterUpload, Converter={StaticResource flags}, ConverterParameter={x:Static common:DeleteFiles.Ai}, Mode=TwoWay}" />
-            <CheckBox Content="Custom" IsChecked="{Binding App.Settings.DeleteAfterUpload, Converter={StaticResource flags}, ConverterParameter={x:Static common:DeleteFiles.Custom}, Mode=TwoWay}" />
-            <CheckBox Content="Brawl" IsChecked="{Binding App.Settings.DeleteAfterUpload, Converter={StaticResource flags}, ConverterParameter={x:Static common:DeleteFiles.Brawl}, Mode=TwoWay}" />
-            <CheckBox Content="Quick match" IsChecked="{Binding App.Settings.DeleteAfterUpload, Converter={StaticResource flags}, ConverterParameter={x:Static common:DeleteFiles.QuickMatch}, Mode=TwoWay}" />
-            <CheckBox Content="Unranked draft" IsChecked="{Binding App.Settings.DeleteAfterUpload, Converter={StaticResource flags}, ConverterParameter={x:Static common:DeleteFiles.UnrankedDraft}, Mode=TwoWay}" />
-            <CheckBox Content="Hero League" IsChecked="{Binding App.Settings.DeleteAfterUpload, Converter={StaticResource flags}, ConverterParameter={x:Static common:DeleteFiles.HeroLeague}, Mode=TwoWay}" />
-            <CheckBox Content="Team League" IsChecked="{Binding App.Settings.DeleteAfterUpload, Converter={StaticResource flags}, ConverterParameter={x:Static common:DeleteFiles.TeamLeague}, Mode=TwoWay}" />
-            <CheckBox Content="Storm League" IsChecked="{Binding App.Settings.DeleteAfterUpload, Converter={StaticResource flags}, ConverterParameter={x:Static common:DeleteFiles.StormLeague}, Mode=TwoWay}" />
-        </StackPanel>
+        <StackPanel Grid.Column="0" Margin="20" helpers:MarginSetter.Margin="0, 8, 0, 0"/>
         <StackPanel Grid.Column="1" Margin="20" helpers:MarginSetter.Margin="0, 8, 0, 0" MinWidth="150">
             <TextBlock Text="Theme:" FontWeight="Bold" Margin="0, 0, 1, 0" />
             <ComboBox SelectedValue="{Binding App.Settings.Theme, Mode=TwoWay}" SelectedValuePath="Tag">
@@ -41,24 +28,16 @@
                 </ComboBox.Items>
             </ComboBox>
             <StackPanel Margin="0, 40, 0, 0">
-                <Button x:Name="Twitch_Extension_Validation_Button" HorizontalAlignment="Stretch" Content="Twitch Extension Validation" Margin="0, 8, 0, 0" Click="Twitch_Extension_Validation_Button_Click"/>
-
-                <TextBlock Text="HP Twitch Extension Info" FontWeight="Bold" Margin="0, 10, 1, 0"/>
                 <Label x:Name="hp_api_email_label" Content="{Binding App.Settings.HPAPIEmail, Mode=TwoWay}" HorizontalAlignment="Center" Margin="5,5,50,0" VerticalAlignment="Top"/>
-                <Label x:Name="twitch_knickname_label" Content="{Binding App.Settings.TwitchNickname, Mode=TwoWay}"  Margin="5,5,50,0"  VerticalAlignment="Top"/>
 
                 <Grid>
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="auto" />
                         <ColumnDefinition Width="auto" />
                     </Grid.ColumnDefinitions>
-                    <StackPanel Grid.Column="0">
-                        <Label x:Name="hp_api_key_label" Content="HP Twitch API Key"  Margin="5,5,10,0"  VerticalAlignment="Top" />
-                    </StackPanel>
+                    <StackPanel Grid.Column="0"/>
 
-                    <StackPanel Grid.Column="1">
-                        <Button x:Name="Show_HP_Api_Key_Button" HorizontalAlignment="Stretch" Content="Show" Margin="0, 8, 0, 0" Click="Show_HP_Api_Key_Button_Click"/>
-                    </StackPanel>
+                    <StackPanel Grid.Column="1"/>
 
                 </Grid>
 

--- a/Heroesprofile.Uploader.Windows/SettingsWindow.xaml.cs
+++ b/Heroesprofile.Uploader.Windows/SettingsWindow.xaml.cs
@@ -34,23 +34,5 @@ namespace Heroesprofile.Uploader.Windows
                 PreReleasePanel.Visibility = Visibility.Visible;
             }
         }
-
-        private void Twitch_Extension_Validation_Button_Click(object sender, RoutedEventArgs e)
-        {
-            new TwitchExtensionValidationWindow() { Owner = this }.ShowDialog();
-        }
-
-        private void Show_HP_Api_Key_Button_Click(object sender, RoutedEventArgs e)
-        {
-            if (showHideButton) {
-                Show_HP_Api_Key_Button.Content = "hide";
-                hp_api_key_label.Content = Properties.Settings.Default.HPKey;
-                showHideButton = false;
-            } else {
-                Show_HP_Api_Key_Button.Content = "show";
-                hp_api_key_label.Content = "HP Twitch API Key";
-                showHideButton = true;
-            }
-        }
     }
 }


### PR DESCRIPTION
closes #26
We've removed the auto delete options from the tool as we do not want the tool to be responsible for deleting replays.